### PR TITLE
Add time option

### DIFF
--- a/coapthon/defines.py
+++ b/coapthon/defines.py
@@ -130,6 +130,7 @@ class OptionRegistry(object):
     PROXY_SCHEME =  OptionItem(39, "Proxy-Schema",  STRING,  False, None)
     SIZE1 =         OptionItem(60, "Size1",         INTEGER, False, None)
     NO_RESPONSE =   OptionItem(258, "No-Response",  INTEGER, False, None)
+    TIME = OptionItem(65000, "Time", INTEGER, False, None)
     RM_MESSAGE_SWITCHING = OptionItem(65524, "Routing", OPAQUE, False, None)
 
     LIST = {
@@ -154,6 +155,7 @@ class OptionRegistry(object):
         39: PROXY_SCHEME,
         60: SIZE1,
         258: NO_RESPONSE,
+        65000: TIME,
         65524: RM_MESSAGE_SWITCHING
 
     }

--- a/coapthon/defines.py
+++ b/coapthon/defines.py
@@ -130,7 +130,7 @@ class OptionRegistry(object):
     PROXY_SCHEME =  OptionItem(39, "Proxy-Schema",  STRING,  False, None)
     SIZE1 =         OptionItem(60, "Size1",         INTEGER, False, None)
     NO_RESPONSE =   OptionItem(258, "No-Response",  INTEGER, False, None)
-    TIME = OptionItem(65000, "Time", INTEGER, False, None)
+    HONO_TIME = OptionItem(65000, "Hono-Time", INTEGER, False, None)
     RM_MESSAGE_SWITCHING = OptionItem(65524, "Routing", OPAQUE, False, None)
 
     LIST = {
@@ -155,7 +155,7 @@ class OptionRegistry(object):
         39: PROXY_SCHEME,
         60: SIZE1,
         258: NO_RESPONSE,
-        65000: TIME,
+        65000: HONO_TIME,
         65524: RM_MESSAGE_SWITCHING
 
     }

--- a/coverage_test.py
+++ b/coverage_test.py
@@ -961,6 +961,7 @@ class Tests(unittest.TestCase):
         exchange3 = (req, expected)
         self.current_mid += 1
 
+        # We're not expecting a request with the time here, just checking we can set the option
         req = Request()
         req.code = defines.Codes.POST.number
         req.uri_path = path
@@ -968,7 +969,7 @@ class Tests(unittest.TestCase):
         req._mid = self.current_mid
         req.destination = self.server_address
         option = Option()
-        option.number = defines.OptionRegistry.TIME.number
+        option.number = defines.OptionRegistry.HONO_TIME.number
         req.add_option(option)
         req.payload = "test"
 

--- a/coverage_test.py
+++ b/coverage_test.py
@@ -961,7 +961,29 @@ class Tests(unittest.TestCase):
         exchange3 = (req, expected)
         self.current_mid += 1
 
-        self._test_with_client([exchange1, exchange2, exchange3])
+        req = Request()
+        req.code = defines.Codes.POST.number
+        req.uri_path = path
+        req.type = defines.Types["CON"]
+        req._mid = self.current_mid
+        req.destination = self.server_address
+        option = Option()
+        option.number = defines.OptionRegistry.TIME.number
+        req.add_option(option)
+        req.payload = "test"
+
+        expected = Response()
+        expected.type = defines.Types["ACK"]
+        expected._mid = self.current_mid
+        expected.code = defines.Codes.CREATED.number
+        expected.token = None
+        expected.payload = None
+        expected.location_path = "storage/new_res"
+
+        exchange4 = (req, expected)
+        self.current_mid += 1
+
+        self._test_with_client([exchange1, exchange2, exchange3, exchange4])
 
     def test_long_options(self):
         """


### PR DESCRIPTION
Adds a new option for fetching time (Option 0xfde8) from the server as made available by Eclipse Hono.

This only implements the option so the client can request it. It does not implement it in the server so that it responds with the time.