### PR TITLE
Use message token to match request and response, remove token from empty message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,3 @@
 
 # CoAPthon3
 CoAPthon3 is a porting to python3 of my CoAPthon library. CoAPthon3 is a python3 library to the CoAP protocol compliant with the RFC. Branch is available for the Twisted framework.
-
-### Notes
-Does not handle multiple requests and should only be used for testing.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,6 @@
 
 # CoAPthon3
 CoAPthon3 is a porting to python3 of my CoAPthon library. CoAPthon3 is a python3 library to the CoAP protocol compliant with the RFC. Branch is available for the Twisted framework.
+
+### Notes
+Does not handle multiple requests and should only be used for testing.

--- a/coapthon/client/helperclient.py
+++ b/coapthon/client/helperclient.py
@@ -235,14 +235,16 @@ class HelperClient(object):
                 return
             try:
                 while True:
-                    response = self.queue.get(block=True, timeout=timeout)
-                    if response is not None:
-                        if response.mid == request.mid:
-                            return response
-                        if response.type == defines.Types["NON"]:
-                            return response
-                    else:
-                        return response
+                    # Not checking message id due to Hono sending CON message with a different id
+                    return self.queue.get(block=True, timeout=timeout)
+                    # response = self.queue.get(block=True, timeout=timeout)
+                    # if response is not None:
+                    #     if response.mid == request.mid:
+                    #         return response
+                    #     if response.type == defines.Types["NON"]:
+                    #         return response
+                    # else:
+                    #     return response
             except Empty:
                 #if timeout is set
                 response = None

--- a/coapthon/client/helperclient.py
+++ b/coapthon/client/helperclient.py
@@ -235,16 +235,14 @@ class HelperClient(object):
                 return
             try:
                 while True:
-                    # Not checking message id due to Hono sending CON message with a different id
-                    return self.queue.get(block=True, timeout=timeout)
-                    # response = self.queue.get(block=True, timeout=timeout)
-                    # if response is not None:
-                    #     if response.mid == request.mid:
-                    #         return response
-                    #     if response.type == defines.Types["NON"]:
-                    #         return response
-                    # else:
-                    #     return response
+                    response = self.queue.get(block=True, timeout=timeout)
+                    if response is not None:
+                        if response.token == request.token:
+                            return response
+                        if response.type == defines.Types["NON"]:
+                            return response
+                    else:
+                        return response
             except Empty:
                 #if timeout is set
                 response = None

--- a/coapthon/layers/messagelayer.py
+++ b/coapthon/layers/messagelayer.py
@@ -290,7 +290,8 @@ class MessageLayer(object):
                 transaction.completed = True
                 message.mid = transaction.response.mid
                 message.code = 0
-                message.token = transaction.response.token
+                # Hono uses strictEmptyMessageFormat and rejects empty messages with a token
+                # message.token = transaction.response.token
                 message.destination = transaction.response.source
 
         elif message.type == defines.Types["RST"]:

--- a/coapthon/layers/messagelayer.py
+++ b/coapthon/layers/messagelayer.py
@@ -290,8 +290,6 @@ class MessageLayer(object):
                 transaction.completed = True
                 message.mid = transaction.response.mid
                 message.code = 0
-                # Hono uses strictEmptyMessageFormat and rejects empty messages with a token
-                # message.token = transaction.response.token
                 message.destination = transaction.response.source
 
         elif message.type == defines.Types["RST"]:


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc7252

In [4.1](https://datatracker.ietf.org/doc/html/rfc7252#section-4.1).  Messages and Endpoints
   _An Empty message has the Code field set to 0.00.  The Token Length
   field MUST be set to 0 and bytes of data MUST NOT be present after
   the Message ID field.  If there are any bytes, they MUST be processed
   as a message format error_
   
In [5.2](https://datatracker.ietf.org/doc/html/rfc7252#section-5.2).  Responses
   _After receiving and interpreting a request, a server responds with a
   CoAP response that is matched to the request by means of a client-
   generated token ([Section 5.3](https://datatracker.ietf.org/doc/html/rfc7252#section-5.3)); note that this is different from the
   Message ID that matches a Confirmable message to its Acknowledgement._